### PR TITLE
Fix worker thread silence caused by uninitialised stopWorker atomic

### DIFF
--- a/src/RadioMusic.cpp
+++ b/src/RadioMusic.cpp
@@ -645,6 +645,8 @@ RadioMusic::RadioMusic() {
 	currentObjectPool = &audioContainer1;
 	tmpObjectPool = &audioContainer2;
 
+	stopWorker.store(false);
+
 	worker = std::make_shared<std::thread>(&RadioMusic::workerThread, this);
 
 	init();
@@ -806,7 +808,7 @@ void RadioMusic::threadedLoad() {
 		if (drwav_init_file(&wav, files[i].c_str(), nullptr)) {
 			object = std::make_shared<WavAudioObject>();
 			if (drwav_uninit(&wav) != DRWAV_SUCCESS) {
-				FATAL("Failed to uninitialize object %zu %s", i, files[i].c_str());
+				FATAL("Failed to uninitialize object %d %s", (int)i, files[i].c_str());
 			}
 		} else { // if load fails, interpret as raw audio
 			object = std::make_shared<RawAudioObject>();
@@ -820,12 +822,12 @@ void RadioMusic::threadedLoad() {
 				tmpObjectPool->objects.push_back(std::move(object));
 				tmpObjectPool->memoryUsage += memory;
 			} else {
-				WARN("Bank memory limit of %ld Bytes exceeded. Aborting loading of audio objects.", MAX_BANK_SIZE);
+				WARN("Bank memory limit of %lld Bytes exceeded. Aborting loading of audio objects.", (long long)MAX_BANK_SIZE);
 				loadError = true;
 				break;
 			}
 		} else {
-			WARN("Failed to load object %zu %s", i, files[i].c_str());
+			WARN("Failed to load object %d %s", (int)i, files[i].c_str());
 			loadError.store(true);
 		}
 	}


### PR DESCRIPTION
std::atomic<bool> is not zero-initialised in C++11. When Rack reuses heap memory from a previously destroyed RadioMusic instance, the new instance's stopWorker can inherit the stale true set by the destructor. The worker thread then exits immediately on startup, preventing any audio files from ever being scanned or loaded, causing permanent silence.

Fix by explicitly storing false into stopWorker before starting the worker thread.

Also fix three format-string mismatches in existing WARN/FATAL calls (%zu and mismatched %ld on Windows) that produced garbled log output.